### PR TITLE
Preserve AutoStart when loading a second file

### DIFF
--- a/MPVPlayer.pas
+++ b/MPVPlayer.pas
@@ -1325,7 +1325,7 @@ begin
 
     mpv_command_(['loadfile', FFileName]);
 
-    mpv_set_pause(not FAutoStart);
+    mpv_set_property_boolean('pause', not FAutoStart);
   end;
 end;
 

--- a/MPVPlayer.pas
+++ b/MPVPlayer.pas
@@ -1319,7 +1319,13 @@ begin
   begin
     FStartAtPosMs := AStartAtPositionMs;
     FFileName := AFileName;
+
+    Loop(0, 0);
+    FPausePosMs := -1;
+
     mpv_command_(['loadfile', FFileName]);
+
+    mpv_set_pause(not FAutoStart);
   end;
 end;
 


### PR DESCRIPTION
G'day,

Firstly - many thanks for this library.  I'm using TMPVPlayer in a multiple channel syncronised playback app, and it's working perfectly.  

In my app, the user can switch between sets of videos. I've a small UI issue when the users loads a second or subsequent se, and I've had to make a change to TMPVPlayer, in .Play.  Currently AutoStartPlayback is not preserved when a second file is loaded.  This patch fixes that.

Cheers

Mike